### PR TITLE
Fix:application.html.haml

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %meta{content: "text/html; charset=UTF-8", http-equiv: "Content-Type"}/
+    %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
     = csp_meta_tag


### PR DESCRIPTION
# What
メタタグ内のハッシュロケットをシンボル型に変更

# Why
読み込み速度向上のため